### PR TITLE
adding feature for extracting UMIs (issue #61)

### DIFF
--- a/atropos/commands/trim/__init__.py
+++ b/atropos/commands/trim/__init__.py
@@ -357,9 +357,9 @@ class CommandRunner(BaseCommandRunner):
             
             if options.paired:
                 modifiers.add_modifier(SyncUMI, 
-                    delim=':')
+                    delim=options.delim)
             else:
-                modifiers.add_modifier(AddUMI, delim = ":")
+                modifiers.add_modifier(AddUMI, delim=options.delim)
 
             
         

--- a/atropos/commands/trim/cli.py
+++ b/atropos/commands/trim/cli.py
@@ -588,13 +588,13 @@ standard output.
         group = self.add_group("UMI options")
         group.add_argument(
             "--read1_umi",
-            type=int, default=None
-            help="How many bases on the 5' end of read 1 are UMI?"
+            type=int, default=None,
+            help="How many bases on the 5' end of read 1 are UMI? (default: 0)"
         )
         group.add_argument(
             "--read2_umi",
             type=int, default=None,
-            help="How many bases on the 5' end of read 2 are UMI?"
+            help="How many bases on the 5' end of read 2 are UMI? (default: 0)"
         )
     
     def validate_command_options(self, options):

--- a/atropos/commands/trim/cli.py
+++ b/atropos/commands/trim/cli.py
@@ -583,6 +583,19 @@ standard output.
             help="Where data compression should be performed. Defaults to "
                  "'writer' if system-level compression can be used and "
                  "(1 < threads < 8), otherwise defaults to 'worker'.")
+
+
+        group = self.add_group("UMI options")
+        group.add_argument(
+            "--read1_umi",
+            type=int, default=None
+            help="How many bases on the 5' end of read 1 are UMI?"
+        )
+        group.add_argument(
+            "--read2_umi",
+            type=int, default=None,
+            help="How many bases on the 5' end of read 2 are UMI?"
+        )
     
     def validate_command_options(self, options):
         parser = self.parser

--- a/atropos/commands/trim/cli.py
+++ b/atropos/commands/trim/cli.py
@@ -585,7 +585,7 @@ standard output.
                  "(1 < threads < 8), otherwise defaults to 'worker'.")
 
 
-        group = self.add_group("UMI options")
+        group = self.add_group("UMI options, clipping UMI from sequence and append to read name")
         group.add_argument(
             "--read1_umi",
             type=int, default=None,
@@ -596,6 +596,12 @@ standard output.
             type=int, default=None,
             help="How many bases on the 5' end of read 2 are UMI? (default: 0)"
         )
+        group.add_argument(
+            "--delim",
+            default=':',
+            help="Deliminator for separating UMI from read ID (default: ':')"
+        )
+
     
     def validate_command_options(self, options):
         parser = self.parser

--- a/atropos/commands/trim/modifiers.py
+++ b/atropos/commands/trim/modifiers.py
@@ -782,6 +782,23 @@ class NEndTrimmer(Trimmer):
         end_cut = end_cut.start() if end_cut else len(read)
         return self.subseq(read, start_cut, end_cut)
 
+class UmiTrimmer(Trimmer):
+    """Trim N bases from 5' end of the read and append to to the read ID
+    """
+
+    def __init__(self, number_of_bases=0):
+        super(UmiTrimmer, self).__init__()
+        self.umi_bases = number_of_bases
+    
+    def __call__(self, read):
+        if number_of_bases:
+            begin, end_bases, new_read = self.subseq(read, umi_bases)
+            return read.sequence[:umi_bases], new_read
+        else:
+            return '', read
+        
+
+
 class RRBSTrimmer(MinCutter):
     """Sequences that are adapter-trimmed are further trimmed 2 bp on the 3'
     end to remove potential methylation-biased bases from the end-repair

--- a/atropos/commands/trim/modifiers.py
+++ b/atropos/commands/trim/modifiers.py
@@ -864,7 +864,8 @@ class AddUMI(Modifier):
         Returns:
             Modified read.
         """
-        read.name = read.name + self.delim + read.umi
+        if read.umi:
+            read.name = read.name + self.delim + read.umi
         return read
 
 

--- a/atropos/commands/trim/modifiers.py
+++ b/atropos/commands/trim/modifiers.py
@@ -681,7 +681,7 @@ class PrefixSuffixAdder(Modifier):
     """Add a suffix and a prefix to read names.
     """
     def __init__(self, prefix="", suffix=""):
-        self.prefiax = prefix
+        self.prefix = prefix
         self.suffix = suffix
     
     def __call__(self, read):

--- a/atropos/commands/trim/modifiers.py
+++ b/atropos/commands/trim/modifiers.py
@@ -814,7 +814,27 @@ class UmiTrimmer(Trimmer):
         else:
             read.add_umi(umi = '')
             return read
-        
+
+def stitch_name(read_name, UMI, delim):
+    '''
+    standardize UMI-appended read name,
+    the resulting read name should be: @{read_name}{delim}{UMI} {DESCRIPTION}
+
+
+    Args:
+        read_name: name of the Sequence object
+        UMI: unique molecular identifier sequence
+        delim: separater for fields
+    
+    Return:
+        A standardized read name
+    '''
+    fields = read_name.split(' ')
+    out_name = fields[0] + delim + UMI 
+    if len(fields) > 1:
+        out_name = out_name +  ' ' +  ' '.join(fields[1:])
+    return out_name
+
 class SyncUMI(ReadPairModifier):
     """Adding UMI read name by syncing UMI from read1 and read2
     """
@@ -841,8 +861,8 @@ class SyncUMI(ReadPairModifier):
         if read2.umi:
             UMI.append(read2.umi)
         UMI = self.delim.join(UMI)
-        read1.name = read1.name + self.delim + UMI
-        read2.name = read2.name + self.delim + UMI
+        read1.name = stitch_name(read1.name, UMI, self.delim)
+        read2.name = stitch_name(read2.name, UMI, self.delim)
         return(read1, read2)
 
 class AddUMI(Modifier):
@@ -865,7 +885,7 @@ class AddUMI(Modifier):
             Modified read.
         """
         if read.umi:
-            read.name = read.name + self.delim + read.umi
+            read.name = stitch_name(read.name, read.umi, self.delim)
         return read
 
 

--- a/atropos/io/_seqio.pyx
+++ b/atropos/io/_seqio.pyx
@@ -26,10 +26,12 @@ cdef class Sequence(object):
         public bint insert_overlap
         public bint merged
         public int corrected
+        public str umi
     
     def __init__(self, str name, str sequence, str qualities=None, str name2='',
                  original_length=None, match=None, match_info=None, clipped=None,
-                 insert_overlap=False, merged=False, corrected=0, alphabet=None):
+                 insert_overlap=False, merged=False, corrected=0, alphabet=None, 
+                 str umi=''):
         
         # Validate sequence and qualities lengths are equal
         if qualities is not None:
@@ -59,6 +61,7 @@ cdef class Sequence(object):
         self.insert_overlap = insert_overlap
         self.merged = merged
         self.corrected = corrected
+        self.umi = umi
     
     def subseq(self, begin=0, end=None):
         if end is None:
@@ -119,6 +122,9 @@ cdef class Sequence(object):
             new_read.match = match
         
         return new_read
+
+    def add_umi(self, umi = ''):
+        self.umi = umi
     
     def __getitem__(self, key):
         """slicing"""


### PR DESCRIPTION
I don't know if you are working on this, but this pull request is a prototype for adding a new feature to extract UMIs from the reads (issue #61). 

Basically, I added three new options to ```trim``` command to clip off the first *N* bases from read1/read2/both reads and append to the read ID.

```
UMI options, clipping UMI from sequence and append to read name:
  --read1_umi READ1_UMI
                        How many bases on the 5' end of read 1 are UMI?
                        (default: 0)
  --read2_umi READ2_UMI
                        How many bases on the 5' end of read 2 are UMI?
                        (default: 0)
  --delim DELIM         Deliminator for separating UMI from read ID (default:
                        ':')
```

In this prototype, I am introducing a new instance variable **UMI** into the **Sequence** object from ```_seqio.pyx```, such that UMIs can be synced between read1 and read2 when the inputs are paired-end. I also implemented two classes of **Modifiers** to:

1. trim *N* bases from sequences and store as **UMI** in the **Sequence** object (```class UmiTrimmer(Trimmer)```), and
2. Appending UMI to the read ID (```class SyncUMI(ReadPairModifier)``` for paired-end, or ```class AddUMI(Modifier)``` for single-end)

I am not sure if these are the best approaches or are there any better ways I can clip and append UMI in one modifier? or syncing the UMIs of a pair of reads without an extra modifier?

Usage example of the current implementation:

1. 4-nt UMIs from both ends:
```
$ atropos trim -pe1 tests/data/paired.1.fastq -pe2 tests/data/paired.2.fastq --read1_umi 4 --read2_umi 4 -o test.1.fq -p test.2.fq  -a ACACTCTTTCCCTACACGACGCTCTTCCGATCT -A GATCGGAAGAGCGGTTCAGCAGGAATGCCGAG --delim ':'
```

Results:
```
$ cat test.1.fq
@read1/1:TTAT:GCTG some text
TTGTCTCCAGCTTAGACATATCGCCT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read2/1:CAAC:TGTG
AGGCCACATTAGACATATCGGATGGT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read3/1:CCAA:TGTT
CTTGATATTAATAACATTAG
+
HHHHHHHHHHHHHHHHHHHH
@read4/1:GACA:CATC
GGCCGTTTGAATGTTGACGGGATGTT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
```

```
$ cat test.2.fq
@read1/2:TTAT:GCTG other text
GAGACAAATAACAGTGGAGTAGTTTT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read2/2:CAAC:TGTG
GCCTGTTGCAGTGGAGTAACTCCAGC
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read3/2:CCAA:TGTT
ATTAATATCAAGTTGGCAGTG
+
HHHHHHHHHHHHHHHHHHHHH
@read4/2:GACA:CATC
CCGTCAACATTCAAACGGCCTGTCCA
+
##########################
```

2. 4-nt UMIs from read 1:
```
$ atropos trim -pe1 tests/data/paired.1.fastq -pe2 tests/data/paired.2.fastq --read1_umi 4 -o test.1.fq -p test.2.fq  -a ACACTCTTTCCCTACACGACGCTCTTCCGATCT -A GATCGGAAGAGCGGTTCAGCAGGAATGCCGAG --delim ':'
```

Results:
```
$ cat test.1.fq                                       
@read1/1:TTAT some text
TTGTCTCCAGCTTAGACATATCGCCT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read2/1:CAAC
AGGCCACATTAGACATATCGGATGGT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read3/1:CCAA
CTTGATATTAATAACATTAG
+
HHHHHHHHHHHHHHHHHHHH
@read4/1:GACA
GGCCGTTTGAATGTTGACGGGATGTT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
```

```
$ cat test.2.fq                                       
@read1/2:TTAT other text
GCTGGAGACAAATAACAGTGGAGTAGTTTT
+
HHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
@read2/2:CAAC
TGTGGCCTGTTGCAGTGGAGTAACTCCAGC
+
###HHHHHHHHHHHHHHHHHHHHHHHHHHH
@read3/2:CCAA
TGTTATTAATATCAAGTTGGCAGTG
+
#HHHHHHHHHHHHHHHHHHHHHHHH
@read4/2:GACA
CATCCCGTCAACATTCAAACGGCCTGTCCA
+
HH############################
```


3. 4-nt UMIs from read 2:
```
$ atropos trim -pe1 tests/data/paired.1.fastq -pe2 tests/data/paired.2.fastq --read2_umi 4 -o test.1.fq -p test.2.fq  -a ACACTCTTTCCCTACACGACGCTCTTCCGATCT -A GATCGGAAGAGCGGTTCAGCAGGAATGCCGAG --delim ':'
```

Results:
```
$ cat test.1.fq                                       
@read1/1:GCTG some text
TTATTTGTCTCCAGCTTAGACATATCGCCT
+
##HHHHHHHHHHHHHHHHHHHHHHHHHHHH
@read2/1:TGTG
CAACAGGCCACATTAGACATATCGGATGGT
+
HHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
@read3/1:TGTT
CCAACTTGATATTAATAACATTAG
+
HHHHHHHHHHHHHHHHHHHHHHHH
@read4/1:CATC
GACAGGCCGTTTGAATGTTGACGGGATGTT
+
HHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
```

```
$ cat test.2.fq                                       
@read1/2:GCTG other text
GAGACAAATAACAGTGGAGTAGTTTT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read2/2:TGTG
GCCTGTTGCAGTGGAGTAACTCCAGC
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read3/2:TGTT
ATTAATATCAAGTTGGCAGTG
+
HHHHHHHHHHHHHHHHHHHHH
@read4/2:CATC
CCGTCAACATTCAAACGGCCTGTCCA
+
##########################
```

4. 4-nt UMIs from single end:
```
$ atropos trim -se tests/data/paired.1.fastq  --read1_umi 4 -o -  -a ACACTCTTTCCCTACACGACGCTCTTCCGATCT -A GATCGGAAGAGCGGTTCAGCAGGAATGCCGAG --delim ':' --quiet
@read1/1:TTAT some text
TTGTCTCCAGCTTAGACATATCGCCT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read2/1:CAAC
AGGCCACATTAGACATATCGGATGGT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
@read3/1:CCAA
CTTGATATTAATAACATTAG
+
HHHHHHHHHHHHHHHHHHHH
@read4/1:GACA
GGCCGTTTGAATGTTGACGGGATGTT
+
HHHHHHHHHHHHHHHHHHHHHHHHHH
```

So I guess if this is moving forward, do you want to include these in this pull request:

1. find a way to do more flexible UMI recognition (something like the interface of [UMI-tools](https://github.com/CGATOxford/UMI-tools/blob/master/doc/QUICK_START.md))?
2. maybe incorporate some quality cutoff for UMI?
3. it is currently silently ignoring ```--read2_umi``` if it is single-end input, would it be more appropriate if a warning or an error is raised?