### PR TITLE
(partial) fix for issue #86

### DIFF
--- a/atropos/io/readers/_impl.py
+++ b/atropos/io/readers/_impl.py
@@ -723,7 +723,7 @@ class BAMParser(BaseSAMParser):
         )
 
     def __init__(self, bam_file: IO, **kwargs):
-        self._reader = self._load_bam_module().AlignmentFile(str(bam_file), **kwargs)
+        self._reader = self._load_bam_module().AlignmentFile(bam_file.name, **kwargs)
 
     @property
     def header(self) -> dict:


### PR DESCRIPTION
This makes atropos not crash with misleading  'File not found' error (see issue #86 which was closed but yet fixed)