### PR TITLE
Make code compatible with Python 3.10

### DIFF
--- a/atropos/commands/base.py
+++ b/atropos/commands/base.py
@@ -1,6 +1,6 @@
 """Common classes/functions used in commands.
 """
-from collections import Sequence
+from collections.abc import Sequence
 import copy
 import platform
 import sys

--- a/atropos/commands/trim/__init__.py
+++ b/atropos/commands/trim/__init__.py
@@ -1,6 +1,7 @@
 """Implementation of the 'trim' command.
 """
-from collections import Sequence, defaultdict
+from collections import defaultdict
+from collections.abc import Sequence
 import logging
 import os
 import sys

--- a/atropos/util/__init__.py
+++ b/atropos/util/__init__.py
@@ -1,6 +1,7 @@
 """Widely useful utility methods.
 """
-from collections import OrderedDict, Iterable, Sequence
+from collections import OrderedDict
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 import errno
 import functools


### PR DESCRIPTION
Import ABCs from `collections.abc`. These classes are no longer available in `collections` in 3.10.

The `collections.abc` module was introduced in 3.3, and atropos supports only Python >= 3.3 (according to the check in _setup.py_), so fortunately there is no need to make this conditional.

(See also bioconda/bioconda-recipes#36914 which applies this patch to the bioconda atropos package.)