### PR TITLE
Replace SafeConfigParser with ConfigParser

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -409,9 +409,8 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
-    with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+    parser = configparser.ConfigParser()
+    parser.read(setup_cfg)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
This resolves https://github.com/jdidion/atropos/issues/135

Testing:
- built with Python 3.11
- built with Python 3.12
