### PR TITLE
docs: archive notice and upstream FR links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: MIT
+
 Atropos began as a fork of Cutadapt [1]. Specifically, it is a fork of commit
 2f3cc0717aa9ff1e0326ea6bcb36b712950d4999 on June 22, 2016. All
 code that remains in its original form is subject to the MIT license (below):

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 [![PyPi](https://img.shields.io/pypi/v/atropos.svg)](https://pypi.python.org/pypi/atropos)
 [![DOI](https://zenodo.org/badge/61393086.svg)](https://zenodo.org/badge/latestdoi/61393086)
 
+> **⚠️ Archived — use [fastp](https://github.com/OpenGene/fastp) or [cutadapt](https://github.com/marcelm/cutadapt) instead.**
+>
+> Atropos has not received substantive feature work since 2019; recent commits are Python version-compatibility fixes only. Most of its capabilities are now covered by actively-maintained tools like fastp. For the small number of atropos-unique features, I've filed feature requests upstream:
+>
+> - [fastp: empirical sequencing-error-rate estimation](https://github.com/OpenGene/fastp/issues/688)
+> - [fastp: library-type presets for common sequencing workflows](https://github.com/OpenGene/fastp/issues/689)
+> - [fastp: standalone adapter-detection subcommand](https://github.com/OpenGene/fastp/issues/690)
+> - [fastp: tile-level QC partitioning via regex on read name](https://github.com/OpenGene/fastp/issues/691)
+> - [cutadapt: empirical sequencing-error-rate estimation](https://github.com/marcelm/cutadapt/issues/881)
+>
+> Niche capabilities that are not being proposed upstream: SAM/BAM input, direct SRA streaming, colorspace (SOLiD) trimming, Jinja2-templated reports. If you depend on any of these, the last release (v1.1.32) will remain installable from PyPI.
+
 # Atropos
 
 Atropos is tool for specific, sensitive, and speedy trimming of NGS reads. It is a fork of the venerable Cutadapt read trimmer (https://github.com/marcelm/cutadapt, [DOI:10.14806/ej.17.1.200](http://dx.doi.org/10.14806/ej.17.1.200)), with the primary improvements being:


### PR DESCRIPTION
**Note:** This MR was largely generated by Claude and has not been completely reviewed by me (the human). You should feel free to defer your review until this warning has been removed.

## Summary
- Adds an "Archived" banner at the top of the README linking to fastp/cutadapt and the 5 upstream feature requests filed for atropos-unique capabilities.
- Adds `SPDX-License-Identifier: MIT` to LICENSE so GitHub recognizes the license.

## Context
After a code-level comparison of atropos vs fastp, atropos is being archived. The audit identified 4 fastp FRs and 1 cutadapt FR covering atropos-unique features worth preserving upstream; niche capabilities (SAM/BAM input, SRA, colorspace, Jinja2 reports) are not being proposed.

## Test plan
- [ ] Confirm the archive banner renders correctly on the repo landing page.
- [ ] Confirm the license is now detected as MIT.